### PR TITLE
indexMap[index] can be nil with filters

### DIFF
--- a/MountJournalEnhanced.lua
+++ b/MountJournalEnhanced.lua
@@ -28,6 +28,10 @@ local function MapIndexToMountId(index)
         ADDON:UpdateIndex()
     end
 
+    if nil == indexMap[index] then
+        return 0
+    end
+
     return indexMap[index][1]
 end
 


### PR DESCRIPTION
You may have a more elegant way to fix this but this seems to do the trick for now with minor testing. Related to #43 