### PR TITLE
chore(db): added Shaohao's Sage Serpent into MoP expansion

### DIFF
--- a/Database/Database.lua
+++ b/Database/Database.lua
@@ -1659,6 +1659,7 @@ ADDON.DB.Expansion = {
         ["minID"] = 448,
         ["maxID"] = 571,
         [467] = true, -- Cataclysmic Gladiator's Twilight Drake
+        [2582] = true, -- Shaohao's Sage Serpent (MoP Classic)
     },
 
     [5] = { -- Warlords of Draenor


### PR DESCRIPTION
# 🐉 Add shaohao sage serpent into mop expansion

Add correct expansion same as Frostbrood Proto-Wyrm (WotLK Classic) and Runebound Firelord (Cataclysm Classic)

<img width="2782" height="514" alt="CleanShot 2025-07-31 at 13 34 57@2x" src="https://github.com/user-attachments/assets/b830aaff-0775-4a84-8f97-6e4949467c27" />

